### PR TITLE
Add repository url to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "mozilla-django-oidc (>=4.0.1,<5.0.0)"
 ]
 
+[project.urls]
+Repository = "http://github.com/Amsterdam/amsterdam-django-oidc.git"
+
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Currently there is no link to this repository on https://pypi.org/project/amsterdam-django-oidc/ .
This PR adds the url to the pyproject.toml file following instructions on: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls