### PR TITLE
Allow skipping of audience validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ AUTHENTICATION_BACKENDS = [
 
 There are also a few settings required in addition to those of the Mozilla package:
 
-| Name                   | Type      | Description                                                                                                      |
-|------------------------|-----------|------------------------------------------------------------------------------------------------------------------|
-| OIDC_OP_ISSUER         | str       | The allowed issuer, the value of the `iss` claim in the access token must match the value of this setting        |
+| Name                   | Type      | Description                                                                                                     |
+|------------------------|-----------|-----------------------------------------------------------------------------------------------------------------|
+| OIDC_OP_ISSUER         | str       | The allowed issuer, the value of the `iss` claim in the access token must match the value of this setting       |
 | OIDC_TRUSTED_AUDIENCES | list[str] | Audiences that we trust, at least one of the values of the `aud` claim must match one the values of this setting |
+| OIDC_VERIFY_AUDIENCE   | bool      | Controls wether or not to verify the `aud` claim, default: `True`                                               |
 
 # Development
 In order to facilitate further development of this package a containerized setup is provided. 

--- a/amsterdam_django_oidc/__init__.py
+++ b/amsterdam_django_oidc/__init__.py
@@ -41,22 +41,23 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
             MUST be rejected if "aud" does not contain a resource indicator of the current resource server
             as a valid audience.
         Therefor we need to handle both cases."""
-        trusted_audiences = self.get_settings("OIDC_TRUSTED_AUDIENCES", [])
-        audiences = payload.get("aud")
-        if audiences is None:
-            raise SuspiciousOperation("Aud claim missing")
+        if self.get_settings("OIDC_VERIFY_AUDIENCE", True):
+            trusted_audiences = self.get_settings("OIDC_TRUSTED_AUDIENCES", [])
+            audiences = payload.get("aud")
+            if audiences is None:
+                raise SuspiciousOperation("Aud claim missing")
 
-        if isinstance(audiences, str):
-            audiences = [audiences]
+            if isinstance(audiences, str):
+                audiences = [audiences]
 
-        trusted_audience_found = False
-        for audience in audiences:
-            if audience in trusted_audiences:
-                trusted_audience_found = True
-                break
+            trusted_audience_found = False
+            for audience in audiences:
+                if audience in trusted_audiences:
+                    trusted_audience_found = True
+                    break
 
-        if not trusted_audience_found:
-            raise PermissionDenied("No trusted audience found")
+            if not trusted_audience_found:
+                raise PermissionDenied("No trusted audience found")
 
     def validate_expiry(self, payload: Payload) -> None:
         """https://learn.microsoft.com/en-us/entra/identity-platform/access-token-claims-reference#payload-claims

--- a/tests/test_oidc_authentication_backend.py
+++ b/tests/test_oidc_authentication_backend.py
@@ -46,6 +46,10 @@ class TestOIDCAuthenticationBackend(TestCase):
         with pytest.raises(SuspiciousOperation):
             self._authentication_backend.validate_audience({})  # type: ignore
 
+    @override_settings(OIDC_VERIFY_AUDIENCE=False)
+    def test_skips_audience_validation(self) -> None:
+        self._authentication_backend.validate_audience({"aud": "someone else"})  # type: ignore
+
     def test_validate_valid_expiry(self) -> None:
         hour_from_now = int(time()) + 3600
         self._authentication_backend.validate_expiry({"exp": hour_from_now})  # type: ignore


### PR DESCRIPTION
Our current Keycloak setup does not provide an audience claim in the access token. Unfortunately that makes it impossible for us to use this library at the moment.